### PR TITLE
GetProperties Method

### DIFF
--- a/Sample/MainWindow.xaml
+++ b/Sample/MainWindow.xaml
@@ -71,5 +71,8 @@
         <TabItem Header="UiService">
             <UserControls:UiService />
         </TabItem>
+        <TabItem Header="Property example">
+            <UserControls:PropertyExample />
+        </TabItem>
     </Controls:MetroAnimatedSingleRowTabControl>
 </Controls:MetroWindow>

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -106,6 +106,10 @@
       <DependentUpon>Paging.xaml</DependentUpon>
     </Compile>
     <Compile Include="UserControls\PagingViewModel.cs" />
+    <Compile Include="UserControls\PropertyExample.xaml.cs">
+      <DependentUpon>PropertyExample.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="UserControls\PropertyExampleViewModel.cs" />
     <Compile Include="UserControls\SettingsWindow.xaml.cs">
       <DependentUpon>SettingsWindow.xaml</DependentUpon>
     </Compile>
@@ -155,6 +159,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="UserControls\Paging.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="UserControls\PropertyExample.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Sample/UserControls/PropertyExample.xaml
+++ b/Sample/UserControls/PropertyExample.xaml
@@ -1,0 +1,86 @@
+﻿<UserControl x:Class="Sample.UserControls.PropertyExample"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:Sample.UserControls"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             mc:Ignorable="d">
+    <UserControl.DataContext>
+        <local:PropertyExampleViewModel />
+    </UserControl.DataContext>
+    <UserControl.Resources>
+        <Style TargetType="{x:Type Button}">
+            <Setter Property="Width" Value="130" />
+            <Setter Property="Margin" Value="3" />
+        </Style>
+    </UserControl.Resources>
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="30" />
+            <RowDefinition Height="30" />
+            <RowDefinition Height="32" />
+            <RowDefinition Height="32" />
+            <RowDefinition Height="30" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Label Grid.Row="0"
+               Grid.Column="0"
+               VerticalAlignment="Center"
+               Content="Value 1:" />
+        <TextBox Grid.Row="0"
+                 Grid.Column="1"
+                 Margin="3"
+                 Text="{Binding ValueOne}" />
+
+        <Label Grid.Row="1"
+               Grid.Column="0"
+               VerticalAlignment="Center"
+               Content="Value 2:" />
+        <TextBox Grid.Row="1"
+                 Grid.Column="1"
+                 Margin="3"
+                 Text="{Binding ValueTwo}" />
+
+        <StackPanel Grid.Row="2"
+                    Grid.Column="1"
+                    FlowDirection="RightToLeft"
+                    Orientation="Horizontal">
+            <Button Command="{Binding ShowReadPropertyCommand}" Content="Readable properties" />
+            <Button Command="{Binding ShowWritePropertyCommand}" Content="Writeable properties" />
+            <Button Command="{Binding ShowReadWritePropertyCommand}" Content="Read / write properties" />
+            <Button Command="{Binding ShowAllPropertyCommand}" Content="All properties" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="3"
+                    Grid.Column="1"
+                    FlowDirection="RightToLeft"
+                    Orientation="Horizontal">
+            <Button Width="160"
+                    Command="{Binding ChangeRaiseCommand}"
+                    Content="Change values / raise event" />
+            <Button Command="{Binding RaiseChangeEventCommand}" Content="Raise change event" />
+            <Button Command="{Binding ChangeValuesCommand}" Content="Change values" />
+        </StackPanel>
+
+        <Label Grid.Row="4"
+               Grid.Column="0"
+               VerticalAlignment="Center"
+               Content="Info:" />
+        <TextBox Grid.Row="4"
+                 Grid.RowSpan="2"
+                 Grid.Column="1"
+                 Margin="3"
+                 AcceptsReturn="True"
+                 AcceptsTab="True"
+                 IsReadOnly="True"
+                 Text="{Binding Info}"
+                 TextWrapping="Wrap" />
+    </Grid>
+</UserControl>

--- a/Sample/UserControls/PropertyExample.xaml.cs
+++ b/Sample/UserControls/PropertyExample.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System.Windows.Controls;
+
+namespace Sample.UserControls
+{
+    /// <summary>
+    /// Interaction logic for PropertyExample.xaml
+    /// </summary>
+    public partial class PropertyExample : UserControl
+    {
+        public PropertyExample()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Sample/UserControls/PropertyExampleViewModel.cs
+++ b/Sample/UserControls/PropertyExampleViewModel.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using WpfUtility.Services;
+
+namespace Sample.UserControls
+{
+    public class PropertyExampleViewModel : ObservableObject
+    {
+        /// <summary>
+        /// Gets or sets the first value
+        /// </summary>
+        public string ValueOne { get; set; } = "The first value";
+
+        /// <summary>
+        /// Gets or sets the second value
+        /// </summary>
+        public string ValueTwo { get; set; } = "Value two";
+
+        /// <summary>
+        /// Backing field for <see cref="Info"/>
+        /// </summary>
+        private string _info = "";
+        /// <summary>
+        /// Gets or sets the info
+        /// </summary>
+        public string Info
+        {
+            get => _info;
+            set => SetField(ref _info, value);
+        }
+
+        /// <summary>
+        /// Command to show the properties
+        /// </summary>
+        public ICommand ShowAllPropertyCommand => new DelegateCommand(() => WriteProperties(PropertyAccessType.Any));
+        /// <summary>
+        /// Command to show readable properties
+        /// </summary>
+        public ICommand ShowReadPropertyCommand => new DelegateCommand(() => WriteProperties(PropertyAccessType.Read));
+        /// <summary>
+        /// Command to show writeable properties
+        /// </summary>
+        public ICommand ShowWritePropertyCommand => new DelegateCommand(() => WriteProperties(PropertyAccessType.Write));
+        /// <summary>
+        /// Command to show read / write able properties
+        /// </summary>
+        public ICommand ShowReadWritePropertyCommand => new DelegateCommand(() => WriteProperties(PropertyAccessType.Read | PropertyAccessType.Write));
+        /// <summary>
+        /// Command to raise the change event
+        /// </summary>
+        public ICommand RaiseChangeEventCommand => new DelegateCommand(() =>
+        {
+            OnPropertyChanged(GetProperties(PropertyAccessType.Write));
+            Info = "'OnPropertyChanged' raised.";
+        });
+        /// <summary>
+        /// Changes the values without a change event
+        /// </summary>
+        public ICommand ChangeValuesCommand => new DelegateCommand(() =>
+        {
+            ValueOne = $"Value one. Time: {DateTime.Now:HH:mm:ss}";
+            ValueTwo = $"Value two. Time: {DateTime.Now:HH:mm:ss}";
+
+            Info = "Values changed.";
+        });
+
+        /// <summary>
+        /// Changes the values and raises the change event
+        /// </summary>
+        public ICommand ChangeRaiseCommand => new DelegateCommand(() =>
+        {
+            ValueOne = $"Value one. Time: {DateTime.Now:HH:mm:ss}";
+            ValueTwo = $"Value two. Time: {DateTime.Now:HH:mm:ss}";
+
+            OnPropertyChanged(GetProperties(PropertyAccessType.Write));
+
+            Info = "Values changed and 'OnPropertyChanged' event raised.";
+        });
+
+        /// <summary>
+        /// Writes the properties
+        /// </summary>
+        private void WriteProperties(PropertyAccessType accessType)
+        {
+            var properties = GetProperties(accessType);
+
+            Info = $"Properties (parameter: {accessType}):";
+            foreach (var property in properties)
+            {
+                Info += $"\r\n- {property}";
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
Added the following two methods:
- `GetProperties(PropertyAccessType accessType = PropertyAccessType.Read | PropertyAccessType.Write, bool onlyPublic = true)`
- `OnPropertyChanged(IEnumerable<string> properties)`

## Reason for the changes
With the Method `GetProperties` it's possible to get all properties of the class, which derives from `ObservableObject`. With the property list it's possible to raise the *PropertyChanged*-Event for all properties without adding them all manually.

With the second method `OnPropertyChanged` it's possible to raise the event for a list of properties so you don't have to write a `foreach` or something like that.

**Example**
```csharp
private Entry _selectedEntry;
public Entry SelectedEntry
{
    get => _selectedEntry;
    set => SetField(ref _selectedEntry, value);
}

public string Name
{
    get => _selectedEntry?.Name ?? "";
    set => SetField(ref _selectedEntry, "Name", value);
}

public int Age
{
    get => _selectedEntry?.Age ?? 0;
    set => SetField(ref _selectedEntry, "Age", value);
}

public void NewEntry()
{
    SelectedEntry = new Entry();

    var readProperties = GetProperties(PropertyAccessType.Read); // All properties which are readable
    var writeProperties = GetProperties(PropertyAccessType.Write); // All properties which are writeable
    var allProperties = GetProperties(PropertyAccessType.All); // All properties
    var properties = GetProperties(); // Loads all properties which are read and writeable
    // Raise the event manually for every property
    foreach (var property in properties)
    {
        OnPropertyChanged(property);
    }

    // Raise the event for a list of properties (new method)
    OnPropertyChanged(properties);
}
```

## Test?
I've added the UserControl `PropertyExample` which contains two properties and some buttons to show the different properties and raise the change event for the properties.